### PR TITLE
Fix typo under Precompiled binaries

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -157,7 +157,7 @@ python setup.py install</code></pre></figure>
 <li><strong>Java</strong> <img src="/images/jar.png" height="24" width="24"></li>
 </ul>
 
-<p>Java binding is availabe in JAR package.</p>
+<p>Java binding is available in JAR package.</p>
 
 <hr>
 


### PR DESCRIPTION
*Java binding is availabe should be __available__.*